### PR TITLE
Allow Ethernet Connections (python)

### DIFF
--- a/docs/library.rst
+++ b/docs/library.rst
@@ -7,8 +7,9 @@ passing the path to a serial device to the constructor.
 .. code:: python
 
     >>> from simple_rpc import Interface
-    >>> 
+    >>>
     >>> interface = Interface('/dev/ttyACM0')
+    >>> ehternet_interface = Interface('socket://192.168.1.151:10000')
 
 Every exported method will show up as a class method of the ``interface`` class
 instance. These methods can be used like any normal class methods.

--- a/docs/library.rst
+++ b/docs/library.rst
@@ -9,7 +9,7 @@ passing the path to a serial device to the constructor.
     >>> from simple_rpc import Interface
     >>>
     >>> interface = Interface('/dev/ttyACM0')
-    >>> ehternet_interface = Interface('socket://192.168.1.151:10000')
+    >>> ethernet_interface = Interface('socket://192.168.1.50:10000')
 
 Every exported method will show up as a class method of the ``interface`` class
 instance. These methods can be used like any normal class methods.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -64,3 +64,10 @@ makes use of the demo_ sketch in the device examples.
 
 .. _example: https://simplerpc.readthedocs.io/en/latest/usage.html#example
 .. _demo: https://github.com/jfjlaros/simpleRPC/blob/master/examples/demo/demo.ino
+
+Ethernet connections
+---------------
+
+To connect to ethernet or WiFi devices:
+
+    $ simple_rpc list -d socket://192.168.1.151:10000

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -70,4 +70,4 @@ Ethernet connections
 
 To connect to ethernet or WiFi devices:
 
-    $ simple_rpc list -d socket://192.168.1.151:10000
+    $ simple_rpc list -d socket://192.168.1.50:10000

--- a/simple_rpc/simple_rpc.py
+++ b/simple_rpc/simple_rpc.py
@@ -19,8 +19,7 @@ class Interface(object):
     def __init__(self, device, baudrate=9600, wait=1, autoconnect=True):
         """Initialise the class.
 
-        :arg str device: Serial device name (e.g. /dev/ttyACM0) or ethernet
-             device name (e.g. socket://192.168.1.151:10000)
+        :arg str device: Serial device name.
         :arg int baudrate: Baud rate.
         :arg int wait: Time in seconds before communication starts.
         :arg bool autoconnect: Automatically connect.

--- a/simple_rpc/simple_rpc.py
+++ b/simple_rpc/simple_rpc.py
@@ -1,7 +1,7 @@
 from time import sleep
 from types import MethodType
 
-from serial import Serial
+from serial import serial_for_url
 from serial.serialutil import SerialException
 
 from .extras import make_function
@@ -19,7 +19,8 @@ class Interface(object):
     def __init__(self, device, baudrate=9600, wait=1, autoconnect=True):
         """Initialise the class.
 
-        :arg str device: Serial device name.
+        :arg str device: Serial device name (e.g. /dev/ttyACM0) or ethernet
+             device name (e.g. socket://192.168.1.151:10000)
         :arg int baudrate: Baud rate.
         :arg int wait: Time in seconds before communication starts.
         :arg bool autoconnect: Automatically connect.
@@ -27,12 +28,14 @@ class Interface(object):
         self._device = device
         self._wait = wait
 
-        self._connection = Serial(baudrate=baudrate)
+        self._connection = serial_for_url(device)
+        self._connection.baudrate = baudrate
         self._version = (0, 0, 0)
         self._endianness = b'<'
         self._size_t = b'H'
         self.methods = {}
 
+        self.close()
         if autoconnect:
             self.open()
 


### PR DESCRIPTION
## Pull Request Details
This is the python side needed to support Ethernet and WiFi101 connections.

## Breaking Changes
In the `Interface` constructor this change will briefly open serial port and close it, this is not exactly the same as the previous behavior but maybe this will not be a noticeable change?

## Issues Fixed
Fixes #2

## Other Relevant Information
Companion PR to [`jfjlaros/simpleRPC` #10](https://github.com/jfjlaros/simpleRPC/pull/11)